### PR TITLE
Return 400 and 401 on expired tokens for PID re-issuance

### DIFF
--- a/application.py
+++ b/application.py
@@ -10,7 +10,7 @@ folder = os.path.dirname(os.path.realpath(__file__))
 
 from request_manager import RequestManager
 
-request_manager = RequestManager(default_expiry_minutes=60)
+request_manager = RequestManager(default_expiry_minutes=1450)
 
 
 def init_oidc_op(app):

--- a/views.py
+++ b/views.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import requests
 
 from cryptojwt import as_unicode
+from cryptojwt.exception import VerificationError
 from flask import Blueprint
 from flask import Response
 from flask import current_app
@@ -20,6 +21,8 @@ from flask import jsonify, abort
 from flask.helpers import make_response
 from flask.helpers import send_from_directory
 import urllib.parse
+
+from idpyoidc.client.oauth2.introspection import Introspection
 from idpyoidc.message.oauth2 import ResponseMessage
 from idpyoidc.message.oidc import AccessTokenRequest
 from idpyoidc.message.oidc import AuthorizationRequest
@@ -676,6 +679,12 @@ def token():
             refresh_token=refresh_token
         )
 
+        if current_request is None:
+            error_message = {
+                "error": "invalid_grant",
+            }
+            return make_response(jsonify(error_message), 400)
+
         session_id = current_request.session_id
 
         # Pass the request form data to service_endpoint
@@ -802,6 +811,11 @@ def service_endpoint(endpoint, get_args=None):
             )
         else:
             args = endpoint.process_request(req_args, http_info=http_info)
+    except VerificationError as ve:
+        message = traceback.format_exception(*sys.exc_info())
+        _log.error(message)
+        _resp = Introspection.response_cls(active=False)
+        args = {"response_args": _resp}
     except Exception as err:
         message = traceback.format_exception(*sys.exc_info())
         _log.error(message)


### PR DESCRIPTION
PID re-issuance changes: a few updates to the source code so 400 and 401 are the status code returned when refresh_token and access_token are expired.

Closes #9 